### PR TITLE
Custom conversion support in superclass properties

### DIFF
--- a/DbDataReaderMapper/CustomPropertyConverter.cs
+++ b/DbDataReaderMapper/CustomPropertyConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -43,7 +44,13 @@ namespace DbDataReaderMapper
 
         internal Delegate this[PropertyInfo key]
         {
-            get => _conversionFunctions.ContainsKey(key) ? _conversionFunctions[key] : null;
+            get
+            {
+                var resolvedKey = _conversionFunctions.Keys.FirstOrDefault(k => k.Name.Equals(key.Name));
+                return resolvedKey == null
+                    ? null
+                    : _conversionFunctions[resolvedKey];
+            }
         }
     }
 }

--- a/DbDataReaderMapper/DbDataReaderMapper.csproj
+++ b/DbDataReaderMapper/DbDataReaderMapper.csproj
@@ -7,14 +7,14 @@
     <Company />
     <PackageProjectUrl>https://github.com/LucaMozzo/DbDataReaderMapper</PackageProjectUrl>
     <RepositoryUrl>https://github.com/LucaMozzo/DbDataReaderMapper</RepositoryUrl>
-    <PackageReleaseNotes>Added support for netstandard2.1, addressing some of the vulnerabilities found in netstandard2.0</PackageReleaseNotes>
+    <PackageReleaseNotes>Added support for custom converter applying on superclass properties conversion</PackageReleaseNotes>
     <NeutralLanguage>en</NeutralLanguage>
     <Description>This library that contains an extension of DbDataReader that automatically maps a database row to a model.</Description>
     <Copyright></Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>db,database,mapper,data,reader</PackageTags>
     <RepositoryType>git</RepositoryType>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
 </Project>

--- a/Tests/Model/EmployeeWrongTypeNeedsConversionBaseClass.cs
+++ b/Tests/Model/EmployeeWrongTypeNeedsConversionBaseClass.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Tests.Model
+{
+    internal class EmployeeWrongTypeNeedsConversionBaseClass
+    {
+        public int Id { get; set; }
+        public int? Age { get; set; }
+        public string FullName { get; set; }
+        public int Address { get; set; } // refers to the address length. Used to test the custom converter on the superclass field
+    }
+}

--- a/Tests/Model/EmployeeWrongTypeNeedsConversionSubclass.cs
+++ b/Tests/Model/EmployeeWrongTypeNeedsConversionSubclass.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tests.Model
+{
+    internal class EmployeeWrongTypeNeedsConversionSubclass : EmployeeWrongTypeNeedsConversionBaseClass
+    {
+        public DateTime? DoB { get; set; }
+        
+        public override bool Equals(object obj)
+        {
+            return obj is EmployeeWrongTypeNeedsConversionSubclass fields &&
+                   Id == fields.Id &&
+                   Age == fields.Age &&
+                   Address == fields.Address &&
+                   FullName == fields.FullName &&
+                   DoB == fields.DoB;
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,17 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-
-    <IsPackable>false</IsPackable>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
-    <PackageReference Include="System.Data.OleDb" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="MSTest" Version="3.7.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="System.Data.OleDb" Version="9.0.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -24,4 +27,7 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This adds support for a case that was not covered with the property converter. The converter was not working when mapping a field that was inherited from a superclass